### PR TITLE
Fetch trading pair

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
   ],
   ignorePatterns: ["build/", "node_modules/", "!.prettierrc.js", "lib/"],
   rules: {
+    camelcase: "error",
     "import/order": [
       "error",
       {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,7 +1,10 @@
 import "@nomiclabs/hardhat-ethers";
 import dotenv from "dotenv";
+import { task } from "hardhat/config";
 import type { HttpNetworkUserConfig } from "hardhat/types";
 import yargs from "yargs";
+
+import { makeTrade } from "./src/make_trade";
 
 const argv = yargs
   .option("network", {
@@ -32,6 +35,12 @@ if (["rinkeby", "mainnet"].includes(argv.network) && INFURA_KEY === undefined) {
     `Could not find Infura key in env, unable to connect to network ${argv.network}`
   );
 }
+
+task("trade", "Makes a random trade on GPv2 given the users balances")
+  .addParam("tokenListUrl", "The token-list to use to identify tradable tokens")
+  .setAction(async ({ tokenListUrl }, hardhatRuntime) => {
+    await makeTrade(tokenListUrl, hardhatRuntime);
+  });
 
 export default {
   solidity: "0.7.3",

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -1,0 +1,79 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
+import { TokenInfo, TokenList } from "@uniswap/token-lists";
+import { BigNumber, Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import fetch from "node-fetch";
+
+async function makeTrade(
+  tokenListUrl: string,
+  { ethers }: HardhatRuntimeEnvironment
+): Promise<void> {
+  const [trader] = await ethers.getSigners();
+
+  const all_tokens = (await fetchTokenList(tokenListUrl)).tokens;
+  const tokens_with_balance = await tokensWithBalance(
+    all_tokens,
+    trader,
+    ethers
+  );
+
+  const { token: sell_token, balance: sell_balance } = selectRandom(
+    tokens_with_balance
+  );
+  const buy_token = selectRandom(
+    all_tokens.filter((token) => sell_token !== token)
+  );
+
+  console.log(
+    `Selling ${sell_balance.toString()} of ${sell_token.name} for ${
+      buy_token.name
+    }`
+  );
+}
+
+async function fetchTokenList(tokenListUrl: string): Promise<TokenList> {
+  const response = await fetch(tokenListUrl);
+  return await response.json();
+}
+
+function selectRandom<T>(list: T[]): T {
+  const index = Math.floor(Math.random() * list.length);
+  return list[index];
+}
+
+interface TokenAndBalance {
+  token: TokenInfo;
+  balance: BigNumber;
+}
+
+async function tokensWithBalance(
+  all_tokens: TokenInfo[],
+  trader: SignerWithAddress,
+  ethers: HardhatEthersHelpers
+): Promise<TokenAndBalance[]> {
+  return (
+    await Promise.all(
+      all_tokens.map(async (token) => {
+        const erc20 = await toERC20(token.address, ethers);
+        const balance: BigNumber = await erc20.balanceOf(trader.address);
+        return {
+          token,
+          balance,
+        };
+      })
+    )
+  ).filter((tokenAndBalance) => {
+    return !tokenAndBalance.balance.isZero();
+  });
+}
+
+async function toERC20(
+  address: string,
+  ethers: HardhatEthersHelpers
+): Promise<Contract> {
+  return new Contract(address, ERC20.abi, ethers.provider);
+}
+
+export { makeTrade };

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -18,6 +18,9 @@ async function makeTrade(
     trader,
     ethers
   );
+  if (tokens_with_balance.length === 0) {
+    throw "Account doesn't have any balance in any of the provided token";
+  }
 
   const { token: sell_token, balance: sell_balance } = selectRandom(
     tokens_with_balance


### PR DESCRIPTION
This PR adds logic to fetch a random token pair for trading given some PK based account and a token list (reusing the Uniswap token list standard). 

The constraint for the sell token is a positive balance. The buy token is randomly chosen from the remaining tokens.

In the next PR we will use this information to sign and send an order to the GPv2 backend.

### Test Plan
export `PK` of an account with some Rinkeby funds.

yarn hardhat trade --token-list-url https://raw.githubusercontent.com/gnosis/gp-swap-ui/89cf4c7f167559d430a3d13dd5caf03255377140/src/custom/tokens/rinkeby-token-list.json  --network rinkeby

logs a reasonable trade with some token that your account has balance of.