### PR TITLE
Wait for trade event to be emitted

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -98,6 +98,7 @@ export async function makeTrade(
   const hasTraded = await waitForTrade(
     GPv2Settlement[chain].address,
     trader.address,
+    uid,
     ethers
   );
   if (!hasTraded) {
@@ -214,6 +215,7 @@ async function giveAllowanceIfNecessary(
 async function waitForTrade(
   contract: string,
   trader: string,
+  uid: string,
   ethers: HardhatEthersHelpers
 ): Promise<boolean> {
   const filter = {
@@ -225,8 +227,11 @@ async function waitForTrade(
   };
 
   const traded = new Promise((resolve: (value: boolean) => void) => {
-    ethers.provider.on(filter, () => {
-      resolve(true);
+    ethers.provider.on(filter, (log) => {
+      // Hacky way to verify that the UID is part of the event data
+      if (log.data.includes(uid.substring(2))) {
+        resolve(true);
+      }
     });
   });
   const timeout = new Promise((resolve: (value: boolean) => void) => {

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -30,6 +30,8 @@ export async function makeTrade(
   const [trader] = await ethers.getSigners();
   const chain = ChainUtils.fromNetwork(network);
 
+  console.log(`Using account ${trader.address}`);
+
   const allTokens = await fetchTokenList(tokenListUrl, chain);
   const tokensWithBalance = await filterTokensWithBalance(
     allTokens,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { Contract } from "@ethersproject/contracts";
+import GPv2SettlementArtefact from "@gnosis.pm/gp-v2-contracts/deployments/mainnet/GPv2Settlement.json";
 import { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
 import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
 import { Network } from "hardhat/types";
@@ -33,4 +34,11 @@ export async function toERC20(
   ethers: HardhatEthersHelpers
 ): Promise<Contract> {
   return new Contract(address, ERC20.abi, ethers.provider);
+}
+
+export async function toSettlementContract(
+  address: string,
+  ethers: HardhatEthersHelpers
+): Promise<Contract> {
+  return new Contract(address, GPv2SettlementArtefact.abi, ethers.provider);
 }


### PR DESCRIPTION
After placing our order we want to assert that it also gets match properly.

This PR subscribes to events on the settlement contract and waits for a Trade event by our user to occur before a certain timeout.

### Test Plan

Export a PK with some rinkeby funds and run:

yarn hardhat trade --token-list-url https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json --network rinkeby

See the script wait until the trade is registered...