### PR TITLE
Check API for executedSellAmount before concluding trade didn't happen

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -63,6 +63,16 @@ export class Api {
       headers: { "Content-Type": "application/json" },
     });
   }
+
+  async getExecutedSellAmount(uid: string): Promise<BigNumber> {
+    const response: OrderDetailResponse = await this.call(`orders/${uid}`);
+    return BigNumber.from(response.executedSellAmount);
+  }
+}
+
+interface OrderDetailResponse {
+  // Other fields are omitted until needed
+  executedSellAmount: string;
 }
 
 interface GetFeeResponse {


### PR DESCRIPTION
The bot failed over night, claiming that e.g. this order was not traded in time

https://protocol-explorer.dev.gnosisdev.com/rinkeby/orders/0xe49e1d61549fdf8f34e3fab131dcd7e2970c3cba2cf26ebb002ddc915d250cf904a66cbba0485d7b21af836f52b711401300fddb605c00b5

However, the order was in fact settled 20s after it was placed: https://rinkeby.etherscan.io/tx/0xbcec7b0b7353766ad3869b06adddffc965e48fe9dee352f94d7f9b90871b9828

My assumption is that this is due to unreliable delivery of event subscriptions.

This PR changes the logic to use the API to query the executed sell amount in case the timeout has been reached. For the case above, this should have returned a non zero value and therefore even if the Trade event is missed, we don't fail.