### PR TITLE
Use amountEstimate rather than fee route as an indicator if a path exists

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -191,7 +191,7 @@ async function getPotentialBuyTokens(
       continue;
     }
     try {
-      await api.getFee(
+      await api.estimateTradeAmount(
         sellToken.address,
         buyToken.address,
         amount,


### PR DESCRIPTION
This addresses the cronjob run failure at noon today, where the error was:

> Calling "https://protocol-rinkeby.dev.gnosisdev.com/api/v1/markets/0xd6801a1DfFCd0a410336Ef88DeF4320D6DF1883e-0x0014F450B8Ae7708593F4A46F8fa6E5D50620F96/sell/12910814179 undefined failed with 404: {"errorType":"NotFound","description":"No price estimate found"}

despite having found a valid fee for the route.

This can happen because for the fee computation we don't care about the buy amount that we receive (in this case it was 0) but only about the length of the pass.

However, if the amount is 0, the price is infinity and therefore we cannot actually trade the provided sellAmount.

This PR therefore uses the amount estimation as a proxy for whether or not we will be able to trade.


I considered failing the fee estimation route in this case, however I think it's nice to have the fee estimation not be sensitive to small amounts (in which case the output amount could be 0) but instead just estimate the baseline path regardless of amounts.


### Test Plan

Script still runs on rinkeby.