### PR TITLE
Provide a maxSlippage parameter for the trade script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This command will fetch a random token pair for which your account has sell bala
 
 It will use a default token list for the specified network. To specify a custom  [@uniswap/token-lists](https://github.com/Uniswap/token-lists) pass in the URL using `--token-list-url`.
 
+It will also limit trades to a maximum of 1% slippage (100 bps). To provide a custom slippage tolerance pass in `--max-slippage-bps`
+
 ## Contributing
 
 Before submitting a PR make sure the changes comply with our linting rules.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,6 +1,6 @@
 import "@nomiclabs/hardhat-ethers";
 import dotenv from "dotenv";
-import { task } from "hardhat/config";
+import { task, types } from "hardhat/config";
 import type { HttpNetworkUserConfig } from "hardhat/types";
 import yargs from "yargs";
 
@@ -41,8 +41,14 @@ task("trade", "Makes a random trade on GPv2 given the users balances")
     "tokenListUrl",
     "The token-list to use to identify tradable tokens"
   )
-  .setAction(async ({ tokenListUrl }, hardhatRuntime) => {
-    await makeTrade(tokenListUrl, hardhatRuntime);
+  .addOptionalParam(
+    "maxSlippageBps",
+    "The maximum slippage the trader is willing to take in bps",
+    100,
+    types.int
+  )
+  .setAction(async ({ tokenListUrl, maxSlippageBps }, hardhatRuntime) => {
+    await makeTrade(tokenListUrl, maxSlippageBps, hardhatRuntime);
   });
 
 export default {


### PR DESCRIPTION
By trading randomly, particularly on xDAI we are doing a lot of bad trades with high slippage (💩💰). My first attempt was to groom the default token list to only allow for more "known" tokens but even there we cannot be guaranteed that there is good liquidity available (e.g. GNO has terrible liquidity on xDAI).

This PR therefore suggests to add an maxSlippage parameter to the execution to limit the trades we are doing to a maximum loss (1% by default). Note, that at the moment we can only estimate slippage as there is not yet an endpoint to get the current spot price of a pair.

While this reduces the token pairs on which we can realistically trade a lot, it will allow to have the bot run more autonomously (right now I have to refill it about once a day)

This should allow us to make bad trades for about a month (@ 1 trade/hour) before we need to refund the trading account.