### PR TITLE
Filter tokens with insufficient balance for fee

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -239,7 +239,6 @@ async function getPotentialBuyTokens(
       ) {
         continue;
       }
-      console.log(maxSlippageBps);
       potentialBuyTokens.push(buyToken);
     } catch {
       // ignoring tokens for which no fee path exists

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -186,7 +186,7 @@ async function filterTradableTokens(
 async function getPotentialBuyTokens(
   sellToken: TokenInfo,
   candidates: TokenInfo[],
-  amount: BigNumber,
+  balance: BigNumber,
   maxSlippageBps: number,
   api: Api
 ): Promise<TokenInfo[]> {
@@ -200,10 +200,10 @@ async function getPotentialBuyTokens(
       const fee = await api.getFee(
         sellToken.address,
         buyToken.address,
-        amount,
+        balance,
         OrderKind.SELL
       );
-      if (fee.gte(amount)) {
+      if (fee.gte(balance)) {
         // We won't have enough balance to pay the fee
         continue;
       }
@@ -212,13 +212,13 @@ async function getPotentialBuyTokens(
       const fullProceeds = await api.estimateTradeAmount(
         sellToken.address,
         buyToken.address,
-        amount,
+        balance,
         OrderKind.SELL
       );
 
       // Check that the trade is not incurring to much slippage.
       // Until we have a spot price endpoint, we can only estimate the slippage by querying proceeds for a much smaller trade amount
-      const fractionalAmount = amount.div(100);
+      const fractionalAmount = balance.div(100);
       const fractionalProceeds = await api.estimateTradeAmount(
         sellToken.address,
         buyToken.address,
@@ -232,7 +232,7 @@ async function getPotentialBuyTokens(
       // too much slippage if (fractionalPrice / fullPrice > 1 + maxSlippageBps)
       if (
         fractionalProceeds
-          .mul(amount)
+          .mul(balance)
           .mul(10000)
           .div(fractionalAmount.mul(fullProceeds))
           .gt(BigNumber.from(10000 + maxSlippageBps))


### PR DESCRIPTION
We are already checking for sufficient sell token balance to pay for the trading fee before placing the order. However, if we get to this point (e.g. because or random token pair picker chose a token for which we only have a breadcrumb amount) we fail the run and cause an alert.

This PR makes it so that these insufficient trade candidates are already filtered before making the random choice.

### Test Plan

Still able to run `yarn hardhat trade --network rinkeby`