### PR TITLE
[Trivial] Wait on Allowance confirmation

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -280,7 +280,7 @@ async function giveAllowanceIfNecessary(
     const tx = await erc20
       .connect(trader)
       .approve(allowanceManager, MAX_ALLOWANCE);
-    await tx.wait;
+    await tx.wait();
     console.log(`✅ Successfully set allowance for ${sellToken.name}`);
   }
 }

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -277,7 +277,10 @@ async function giveAllowanceIfNecessary(
   const erc20 = await toERC20(sellToken.address, ethers);
   const allowance = await erc20.allowance(trader.address, allowanceManager);
   if (allowance.lt(sellAmount)) {
-    await erc20.connect(trader).approve(allowanceManager, MAX_ALLOWANCE);
+    const tx = await erc20
+      .connect(trader)
+      .approve(allowanceManager, MAX_ALLOWANCE);
+    await tx.wait;
     console.log(`✅ Successfully set allowance for ${sellToken.name}`);
   }
 }


### PR DESCRIPTION
We ran into a mainnet failure of the bot tonight. The trade didn’t happen because the approve transaction took 46 minutes to mine: https://etherscan.io/tx/0x579975cd6a651c896ca89685baf48a0cbd0c34da22ee05022cd1bb6b56f4da7c

This PR changes the bot to first wait on the approve transaction to mine before attempting to place an order.

### Test Plan

Local rinkeby dry run