### PR TITLE
Upgrade to latest contract version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@gnosis.pm/gp-v2-contracts": "0.0.1-alpha.16",
+    "@gnosis.pm/gp-v2-contracts": "1.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@openzeppelin/contracts": "^4.2.0",
     "@types/node-fetch": "^2.5.12",

--- a/src/api.ts
+++ b/src/api.ts
@@ -63,6 +63,7 @@ export class Api {
         signature: signature.signature,
         signingScheme: signature.signatureScheme,
         receiver: order.receiver,
+        from: signature.signer,
       }),
       headers: { "Content-Type": "application/json" },
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,6 +65,7 @@ export async function toSettlementContract(
 
 export class Signature {
   constructor(
+    public readonly signer: string,
     public readonly signature: string,
     public readonly signatureScheme: string
   ) {}
@@ -85,6 +86,7 @@ export class Signature {
       scheme
     );
     return new Signature(
+      trader.address,
       ethers.utils.joinSignature(rawSignature.data),
       schemeName
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,10 +447,10 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
-"@gnosis.pm/gp-v2-contracts@0.0.1-alpha.16":
-  version "0.0.1-alpha.16"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-0.0.1-alpha.16.tgz#6e326e5e2ec845992c7f9f6fc32189c1505ab5b4"
-  integrity sha512-5sufwG3WTotLDRJLw6Y7f1e2HRYEWxSNRwC4xZ5GipQ3EobOpCPKGUIp3iZy0wJa0we0CMyFZtT0WQeVbik7xw==
+"@gnosis.pm/gp-v2-contracts@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.0.2.tgz#bcc1f6a07061df6ab55298d7fe6ee93fcd1025aa"
+  integrity sha512-bsWB8r8RENvpAGMRfRfENtMU7tPdfa1AtgTidUpxC9f3HREZ2FdiAvAghE3XZwy7BzJ0CQJ2lNl4ANKCZ+kj8Q==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
This PR upgrades the trading bot to the latest settlement contract. Some minor formatting changes were also done to the log message so that balance are printed in base units instead of atoms.

### Test Plan

<details><summary>Check that it fails for the current network because <code>Address recovered from signature 0xf805…3adb does not match from address</code></summary>

```
$ npx hardhat trade --network rinkeby
💰 Using account 0x3a2C5d8f209F12bdcd84A46D6eEB136Cbb0ccb9c
🔏 Signed with "eip712"
🤹 Selling 0.9997999999972 of Wrapped Ether for 0.000848070685532434 of Maker with a 0.0002000000028 fee
An unexpected error occurred.

Calling "https://protocol-rinkeby.dev.gnosisdev.com/api/v1/orders {"method":"post","body":"{\"sellToken\":\"0xc778417E063141139Fce010982780140Aa0cD5Ab\",\"buyToken\":\"0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85\",\"sellAmount\":\"999799999997200000\",\"buyAmount\":\"843830332104771\",\"validTo\":1628066311,\"appData\":\"0xf6a005bde820da47fdbb19bc07e56782b9ccec403a6899484cf502090627af8a\",\"feeAmount\":\"200000002800000\",\"kind\":\"sell\",\"partiallyFillable\":false,\"signature\":\"0x7d5bb4fca30a6c89e790dbf4a437e070d83c1633f66ab0871fa0aa21f5b283e13eb4cadd1b88b3ecc04f6a7007dc80875cb3c440375ecd4393e86fcf869c6a7c1b\",\"signingScheme\":\"eip712\",\"from\":\"0x3a2C5d8f209F12bdcd84A46D6eEB136Cbb0ccb9c\"}","headers":{"Content-Type":"application/json"}} failed with 400: {"errorType":"WrongOwner","description":"Address recovered from signature 0xf805…3adb does not match from address"}
```

</details>

In order to test against the new smart contracts:
<details><summary>Setup local rinkeby solver and orderbook instances:</summary>

```
$ export NODE_URL=https://rinkeby.infura.io/v3/$INFURA_PROJECT_ID
$ cargo run -p orderbook -- --skip-trace-api true --base-tokens 0xc778417e063141139fce010982780140aa0cd5ab --fee-discount-factor 1
$ cargo run -p solver -- --orderbook-url http://localhost:8080
```

</details>
<details><summary>Apply a small patch to make use of this instances with the trading bot:</summary>

```diff
diff --git a/src/api.ts b/src/api.ts
index da378bf..92f3f86 100644
--- a/src/api.ts
+++ b/src/api.ts
@@ -12,7 +12,8 @@ export class Api {
   }
 
   private async call<T>(route: string, init?: RequestInit): Promise<T> {
-    const url = `https://protocol-${this.network}.dev.gnosisdev.com/api/v1/${route}`;
+    //const url = `https://protocol-${this.network}.dev.gnosisdev.com/api/v1/${route}`;
+    const url = `http://localhost:8080/api/v1/${route}`;
     const response = await fetch(url, init);
     const body = await response.text();
     if (!response.ok) {
```

</details>
<details><summary>Check that the trading bot succeeds:</summary>

```
$ npx hardhat trade --network rinkeby
💰 Using account 0x3a2C5d8f209F12bdcd84A46D6eEB136Cbb0ccb9c
🤹 Selling 0.987080713428795804 of Wrapped Ether for 0.000837281616964166 of Maker with a 0.0002000000016 fee
🔏 Signed with "eip712"
✅ Successfully placed order with uid: 0x610cb246c2236e9176ccf8b9c9d298c65a1555ffea686ade334d569533e560373a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c610a700c

⏳ Waiting up to 300s for trade event...
🎉 Trade was successful! New Maker balance: 0.000837281616964166
```

</details>

Check [the settlement transaction](https://rinkeby.etherscan.io/tx/0x0520bfa1bf410521c2dd1b88b0d24d9b744084aa49256f52cb7b3a3594bf4b11) for the trade :point_up: that it:
- Was for the [upgraded settlement contract](https://rinkeby.etherscan.io/address/0x9008d19f58aabd9ed0d60971565aa8510560ab41)
- That the order ID was traded by inspecting the [event log](https://rinkeby.etherscan.io/tx/0x0520bfa1bf410521c2dd1b88b0d24d9b744084aa49256f52cb7b3a3594bf4b11#eventLog) includes the order UID `0x610cb24`.