### PR TITLE
Random signature scheme

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -103,6 +103,8 @@ export async function makeTrade(
     fee
   );
   const signature = await Signature.fromOrder(order, chain, trader);
+  console.log(`🔏 Signed with "${signature.signatureScheme}"`);
+
   const uid = await api.placeOrder(order, signature);
   console.log(`✅ Successfully placed order with uid: ${uid}`);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
 import {
-  domain,
+  EcdsaSigningScheme,
   Order,
   SigningScheme,
+  domain,
   signOrder,
 } from "@gnosis.pm/gp-v2-contracts";
 import GPv2SettlementArtefact from "@gnosis.pm/gp-v2-contracts/deployments/mainnet/GPv2Settlement.json";
@@ -73,15 +74,19 @@ export class Signature {
     chain: Chain,
     trader: SignerWithAddress
   ): Promise<Signature> {
+    const [scheme, schemeName] = selectRandom<[EcdsaSigningScheme, string]>([
+      [SigningScheme.EIP712, "eip712"],
+      [SigningScheme.ETHSIGN, "ethsign"],
+    ]);
     const rawSignature = await signOrder(
       domain(chain, GPv2Settlement[chain].address),
       order,
       trader,
-      SigningScheme.ETHSIGN
+      scheme
     );
     return new Signature(
       ethers.utils.joinSignature(rawSignature.data),
-      "ethsign"
+      schemeName
     );
   }
 }


### PR DESCRIPTION
Now that `hardhat ^2.2.0` supports off-chain EIP-712 signatures for networks other than `hardhat` (there was previously a bug which is now fixed) we can randomize the signing scheme that the bot uses :game_die:.

### Test Plan

Run a few times to make sure both signing schemes work:
```
$ npx hardhat trade --network rinkeby 
Using account 0x3a2C5d8f209F12bdcd84A46D6eEB136Cbb0ccb9c
🤹 Selling 993421317879793975 of Wrapped Ether for 842660001477381 of Maker with a 200000002800000 fee
🔏 Signed with "eip712"
✅ Successfully placed order with uid: 0xc24734dbc6b12ecf9982348142405fc96c0f50571669b1b35f0017f6f8ab66953a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c610a57a9

⏳ Waiting up to 300s for trade event...
Trade was successful 🎉 ! New Maker balance: 842660001477381
$ npx hardhat trade --network rinkeby
Using account 0x3a2C5d8f209F12bdcd84A46D6eEB136Cbb0ccb9c
🤹 Selling 842489627772808 of Maker for 987280713430396027 of Wrapped Ether with a 170373704573 fee
🔏 Signed with "ethsign"
✅ Successfully placed order with uid: 0x266601925ba036e693863b1d731db3b922fa5efedbacfdfa689c01e13d717da73a2c5d8f209f12bdcd84a46d6eeb136cbb0ccb9c610a57fd

⏳ Waiting up to 300s for trade event...
Trade was successful 🎉 ! New Wrapped Ether balance: 987280713430395804
``` 