### PR TITLE
Fix xDAI node issue (EIP-1559)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -71,6 +71,8 @@ export default {
     },
     xdai: {
       ...sharedNetworkConfig,
+      // Fix a gas price so that hardhat doesn't try to use EIP1559 which isn't supported on xDAI (but exposed by recent OE nodes)
+      gasPrice: 1e9,
       chainId: 100,
       url: NODE_URL || "https://xdai.poanetwork.dev",
     },


### PR DESCRIPTION
xDAI doesn't support EIP-1559. Yet, when connecting to https://dev-openethereum.xdai.gnosisdev.com (OE 3.3) and asking for `eth_feeHistory` we get a valid response making hardhat believe that EIP1559 is supported.

Other nodes (e.g. https://xdai.poanetwork.dev,  quiknode) don't implement that method and therefore hardhat uses a legacy transaction type.

This PR force hardhat to always use legacy transactions on xDAI by hardcoding a gasPrice in the network configuration.

I also created https://github.com/openethereum/openethereum/issues/515 to track the issue in the OE client. Given its deprecation the issue will likely not get addressed.

### Test Plan

Pointing against internal xDAI node (needed to proxy because of cert issues) I made sure that with gasPrice set in the config we send raw transactions without a transaction type (0x02)