### PR TITLE
Recover from high slippage

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -47,14 +47,30 @@ task("trade", "Makes a random trade on GPv2 given the users balances")
     "The token-list to use to identify tradable tokens"
   )
   .addOptionalParam(
-    "maxSlippageBps",
-    "The maximum slippage the trader is willing to take in bps",
+    "acceptableSlippageBps",
+    "The normal slippage threshold for a standard trade in bps",
     100,
     types.int
   )
-  .setAction(async ({ tokenListUrl, maxSlippageBps }, hardhatRuntime) => {
-    await makeTrade(tokenListUrl, maxSlippageBps, hardhatRuntime);
-  });
+  .addOptionalParam(
+    "maxSlippageBps",
+    "If no trades are possible with acceptable slippage, it tries to trade back to a good state unless the trade exceeds this slippage threshold in bps",
+    1000,
+    types.int
+  )
+  .setAction(
+    async (
+      { tokenListUrl, maxSlippageBps, acceptableSlippageBps },
+      hardhatRuntime
+    ) => {
+      await makeTrade(
+        tokenListUrl,
+        acceptableSlippageBps,
+        maxSlippageBps,
+        hardhatRuntime
+      );
+    }
+  );
 
 export default {
   solidity: "0.7.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node-fetch": "^2.5.12",
     "@types/yargs": "^17.0.2",
     "@uniswap/token-lists": "^1.0.0-beta.25",
+    "canonical-weth": "^1.4.0",
     "dotenv": "^10.0.0",
     "ethers": "^5.4.3",
     "hardhat": "^2.5.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import { GPv2Settlement } from "@gnosis.pm/gp-v2-contracts/networks.json";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
 import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
+import WethNetworks from "canonical-weth/networks.json";
 import { Contract, ethers } from "ethers";
 import { Network } from "hardhat/types";
 
@@ -34,6 +35,17 @@ export class ChainUtils {
         return "https://raw.githubusercontent.com/Uniswap/token-lists/master/test/schema/bigexample.tokenlist.json";
       case Chain.XDAI:
         return "https://tokens.honeyswap.org/";
+    }
+  }
+
+  static nativeToken(chain: Chain): string {
+    switch (chain) {
+      case Chain.MAINNET:
+        return WethNetworks.WETH9[1].address;
+      case Chain.RINKEBY:
+        return WethNetworks.WETH9[4].address;
+      case Chain.XDAI:
+        return "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,6 +1085,11 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+canonical-weth@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/canonical-weth/-/canonical-weth-1.4.0.tgz#e6b16574443e8ff0a132f1b4947bb2faf8c3e078"
+  integrity sha512-9rkLfAFndWALLhxd5lpyTX4RkV36WmVBZ92NYtYr1kWdAUmclRp7I5KkK4wvogzDcCI++yw53TLwx/GCPcocMg==
+
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
If slippage is too high for all traded tokens, try to recover by trading back the held token to WETH with a higher slippage.

This is basically what I do when the trading bot is stuck because of high slippage, and it should likely increase the amount of signal in a trading bot failure alert.

Note: the command-line argument names have been changed, so also the Kubernetes configs should change accordingly.

### Test plan

<details><summary>Tried out on xDai while the trading bot was stuck</summary>

```
$ yarn hardhat trade --network xdai
yarn run v1.22.10
$ /path/gp-v2-trading-bot/node_modules/.bin/hardhat trade --network xdai
💰 Using account 0x04a66CBbA0485D7B21Af836f52b711401300FDdb
  [DEBUG] Selling Dai Stablecoin from Ethereum for McDonaldsCoin on xDai: Too much slippage (7.74%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Own a fraction: Too much slippage (6.79%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for XY Oracle on xDai: Too much slippage (7.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Phala on xDai: Too much slippage (9159.41%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Kyber Network Crystal on xDai: Too much slippage (1096.28%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for ChainLink Token from Ethereum: Too much slippage (20.53%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for renBTC on xDai: Too much slippage (7.48%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Enjin Coin on xDai: Too much slippage (7.21%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Robonomics on xDai: Too much slippage (3659.49%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Donut on xDai: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Stake Token on xDai: Too much slippage (7.08%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Freedom Reserve on xDai: Too much slippage (7.78%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for HEX on xDai: Too much slippage (6.79%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for tBTC on xDai: Too much slippage (9.38%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Bricks on xDai: Too much slippage (6.79%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Unifty on xDai: Too much slippage (7.65%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for XionGlobal Token: Too much slippage (6.79%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Gnosis from Ethereum: Too much slippage (6.84%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Symmetric: Too much slippage (7.38%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Polyient Games Governance Token: Too much slippage (3932.25%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for MORPHINE: Too much slippage (7.14%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Rarible on xDai: Too much slippage (7.34%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for MEDOOZA Ecosystem v2.0 from Ethereum: Too much slippage (8.58%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Xion Global Token: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for xdai dao: Too much slippage (25.57%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for PILLAR from Ethereum: Too much slippage (6.84%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for AlbCoin from Ethereum: Too much slippage (7.11%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Agave: Too much slippage (6.62%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for FOX from Ethereum: Too much slippage (27.27%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Adept Coin Governance from Ethereum: Too much slippage (8.08%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Metronome on xDai: Too much slippage (27.56%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for MetaFactory on xDai: Too much slippage (23.61%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Dai Token from BSC: Too much slippage (7.42%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for FreeToken: Too much slippage (8.00%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for SwissBorg Token on xDai: Too much slippage (7.01%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Unit Protocol: Too much slippage (10.40%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for EthLend Token on xDai: Too much slippage (14.05%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for UniBright on xDai: Too much slippage (6.92%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Base Protocol on xDai: Too much slippage (143.28%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Synth sETH on xDai: Too much slippage (8567.09%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Unilayer on xDai: Too much slippage (6762.16%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Tether on xDai: Too much slippage (7.66%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for 1INCH Token on xDai: Too much slippage (7.09%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Perpetual on xDai: Too much slippage (7.10%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for DXdao from Ethereum: Too much slippage (11.17%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Republic Token on xDai: Too much slippage (7.69%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for JPY Coin on xDai: Too much slippage (7.73%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BarnBridge: Too much slippage (8.38%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Panvala pan on xDai: Too much slippage (6.44%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Contribute on xDai: Too much slippage (13.43%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Decentralized Insurance Protocol on xDai: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for coin_artist on xDai: Too much slippage (16.20%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Trips on xDai: Too much slippage (6.77%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for SushiToken on xDai: Too much slippage (8.35%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for HOPR Token on xDai: Too much slippage (6.90%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for PolkastarterToken on xDai: Too much slippage (2666.58%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Golden Bull Token on xDAI: Too much slippage (2603.15%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Honey: Too much slippage (7.35%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Trace Token on xDai: Too much slippage (7.04%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for DAppNode DAO Token from Ethereum: Too much slippage (8.36%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for DAOstack on xDai: Too much slippage (688.03%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for OM Token on xDai: Too much slippage (4358.63%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for yCurve on xDai: Too much slippage (14.29%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Terra Virtua Kolect: Too much slippage (8.59%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for LUKSO Token on xDai: Too much slippage (7.08%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Particle: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Testa on xDai: Too much slippage (9.69%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Wrapped CHI from Ethereum: Too much slippage (6.84%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Bancor Network Token on xDai: Too much slippage (8.08%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Unisocks: Too much slippage (62.88%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Aragon Network Token on xDai: Too much slippage (11.14%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Yield on xDai: Too much slippage (7.56%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BandToken on xDai: Too much slippage (6485.36%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for xMOON on xDai: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Standard on xDai: Too much slippage (2388.58%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for TrueUSD on xDai: Too much slippage (1679.34%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Basic Attention Token on xDai: Too much slippage (8.14%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Audius on xDai: Too much slippage (26.03%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for SHE Sweatpants: Too much slippage (6.80%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Reserve Rights on xDai: Too much slippage (9.93%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BTCCB: Too much slippage (330.25%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for HoloToken on xDai: Too much slippage (12.87%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Autopia Token on xDai: Too much slippage (6.78%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BUSD Token from BSC: Too much slippage (7.32%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Darwinia Network Native Token on xDai: Too much slippage (144.92%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BLOCKMESH: Too much slippage (823.44%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Compound on xDai: Too much slippage (8.70%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Minerva Wallet SuperToken: Too much slippage (6.77%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Cheemscoin: Too much slippage (7.80%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Balancer on xDai: Too much slippage (8.38%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Synthetix Network Token on xDai: Too much slippage (7.21%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Matic Token on xDai: Too much slippage (9.48%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BlackDragon Token on xDai: Too much slippage (5144.42%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for USD Coin on xDai binance-peg: Too much slippage (38.69%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for HiveShares from Ethereum: Too much slippage (7.25%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Aave Token on xDai: Too much slippage (8.66%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Ethereum Meta on xDai: Too much slippage (9900.00%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for AMIS on xDai: Too much slippage (16.06%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Ocean Token on xDai: Too much slippage (109.35%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Wrapped ETHO: Too much slippage (7.95%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Energy Web Token Bridged on xDai: Too much slippage (6.93%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for SNAFU: Too much slippage (6.77%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Meridian Network on xDai: Too much slippage (9900.00%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Maker on xDai: Too much slippage (12.92%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for AirSwap Token on xDai: Too much slippage (3216.83%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for renZEC on xDai: Too much slippage (2615.39%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for MEME on xDai: Too much slippage (6.80%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Rocket Pool on xDai: Too much slippage (7.68%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for xREAP: Too much slippage (324.05%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Layer 2 Index on xDai: Too much slippage (9.20%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Axie Infinity: Too much slippage (9.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for USDC from Ethereum: Too much slippage (7.69%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BZZ from Ethereum: Too much slippage (7.33%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Bidao on xDai: Too much slippage (7.00%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for xDai Native Comb: Too much slippage (6.90%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for FTX Token: Too much slippage (9900.00%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Wrapped BNB from BSC: Too much slippage (6.81%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Akropolis on xDai: Too much slippage (9.91%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for 0xMonero from Ethereum: Too much slippage (10.55%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Energi on xDai: Too much slippage (85.79%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BaoToken on xDai: Too much slippage (7.00%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Concentrated Voting Power on xDai: Too much slippage (6571.18%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Wrapped Ether from Ethereum: Too much slippage (7.06%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for UniTrade on xDai: Too much slippage (59.60%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Davincij15 Token on xDai: Too much slippage (9355.38%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for JOON on xDai: Too much slippage (6.87%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Streamr DATA on xDai: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Uniswap on xDai: Too much slippage (8.08%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Raid Guild Token from Ethereum: Too much slippage (6.80%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Badger on xDai: Too much slippage (7.15%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for BaoToken Coupon: Too much slippage (213.93%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Yearn Finance on xDai: Too much slippage (8.79%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for 0x Protocol Token on xDai: Too much slippage (8.95%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for OWL on xDai: Too much slippage (10.04%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for OMGToken on xDai: Too much slippage (8.98%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for prophet.finance on xDai: Too much slippage (1116.59%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Sora Token on xDai: Too much slippage (9900.00%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Decentraland MANA on xDai: Too much slippage (7.44%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for COLD TRUTH CASH: Too much slippage (6.78%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for UniCrypt on xDai: Too much slippage (7.21%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for DefiPulse Index from Ethereum: Too much slippage (125.02%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Ampleforth on xDai: Too much slippage (383.95%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Synthetix USD on xDai: Too much slippage (8552.77%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Cream on xDai: Too much slippage (30.69%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Graph Token on xDai: Too much slippage (13.04%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for SURF.Finance from Ethereum: Too much slippage (6.78%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for CFX Quantum from Ethereum: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Celsius on xDai: Too much slippage (224.42%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Wrapped XDAI: Too much slippage (7.43%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Haus: Too much slippage (7.22%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for POA20 on xDai: Too much slippage (8.66%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for FalconSwap Token on xDai: Too much slippage (116.04%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Wrapped BTC on xDai: Too much slippage (6.46%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for UNCL on xDai: Too much slippage (6.76%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Curve DAO Token on xDai: Too much slippage (10.08%)
  [DEBUG] Selling Dai Stablecoin from Ethereum for Enigma on xDai: Too much slippage (861.80%)
[DEBUG] No tokens available with acceptable slippage, trying to buy native token next
🤹 Selling 2.090414854217022848 of Dai Stablecoin from Ethereum for 2.085166300118575612 of Wrapped XDAI with a 0.000399583090217662 fee
🔏 Signed with "ethsign"
✅ Successfully placed order with uid: 0x6c2f55260cf04382f28c1613bc240e5db4f0a1e9b510f1d7ecd952a3292de38e04a66cbba0485d7b21af836f52b711401300fddb61335c7d

⏳ Waiting up to 300s for trade event...
🎉 Trade was successful! New Wrapped XDAI balance: 2.085166300118575612
Done in 108.08s.
```
</details>