### PR TITLE
Fix xDAI bot getting stuck in token without valid fee estimate

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -319,6 +319,14 @@ async function getFirstBuyToken(
         balance,
         OrderKind.SELL
       );
+      // Also check that a fee path exist in the opposite direction (may not be the case if target token is illiquid)
+      // so the the bot doesn't get stuck on an illiquid token
+      await api.getFee(
+        buyToken.address,
+        sellToken.address,
+        balance,
+        OrderKind.BUY
+      );
     } catch {
       // no fee path exists, ignoring
       continue;


### PR DESCRIPTION
More context on underlying reason: https://gnosisinc.slack.com/archives/C020UHS2UEL/p1632426373012400

A recent change made it so that we may trade a liquid token (e.g. xWETH) into an illiquid token (e.g. xYLD) but not the other way around (to estimate the fee we price $1k of the sell token into the native token - wxDAI in the example - which has enough liquidity for WETH but not for YLD).

This made the trading bot get stuck frequently, as it would trade into an illiquid token from which it can no longer return (not even to wxDAI). We might want to rethink this behavior overall (seems weird that you can buy a shitcoin, but not sell it), however for now I'm fixing the trading bot so that it doesn't choose a token from which it cannot compute a fee back to the original token.

### Test Plan
Made a test trade: https://blockscout.com/xdai/mainnet/tx/0xa3b8fa3a0fe8e4706275ac18c36cc51829400e00e870c41a4216c2b5267dad61 (reverse direction is tradable)