### PR TITLE
attempt to retry on fee quote

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -138,8 +138,8 @@ async function fetchTokenList(
 }
 
 async function seekTradablePair(
-  tokensWithBalance: any,
-  trader: any,
+  tokensWithBalance: SellTokenCandidate[],
+  trader: SignerWithAddress,
   chain: Chain,
   api: Api,
   maxRetries: number,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,14 +12,14 @@ import { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
 import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
 import { TokenInfo } from "@uniswap/token-lists";
 import WethNetworks from "canonical-weth/networks.json";
-import { Contract, ethers } from "ethers";
+import { BigNumber, Contract, ethers } from "ethers";
 import { Network } from "hardhat/types";
 
 export type QuoteDetails = {
   sellToken: TokenInfo;
   buyToken: TokenInfo;
-  fee: any;
-  sellBalance: any;
+  fee: BigNumber;
+  sellBalance: BigNumber;
 };
 export class ChainUtils {
   static fromNetwork(network: Network): Chain {


### PR DESCRIPTION
Closes #34 

Trying to find a way to fail less on a single run. Idea is to retry the random token selection 5 times to see if a fee can be fetched. Might also try buy wrapped native token if all 5 tries fail (or buy the token sold on the previous successful run). 


- [ ] TODO - run locally after solving below issue.

Have been struggling with a local testing issue (when testing with specified networks)

```sh
➜  gp-v2-trading-bot git:(main) ✗ yarn hardhat trade --network mainnet
yarn run v1.22.11
$ /Users/bensniff/Projects/gnosis/gp-v2-trading-bot/node_modules/.bin/hardhat trade --network mainnet
An unexpected error occurred:

TypeError: Only absolute URLs are supported
    at getNodeRequestOptions (/Users/bensniff/Projects/gnosis/gp-v2-trading-bot/node_modules/node-fetch/lib/index.js:1305:9)
    at /Users/bensniff/Projects/gnosis/gp-v2-trading-bot/node_modules/node-fetch/lib/index.js:1410:19
    at new Promise (<anonymous>)
    at fetch (/Users/bensniff/Projects/gnosis/gp-v2-trading-bot/node_modules/node-fetch/lib/index.js:1407:9)
    at HttpProvider._fetchJsonRpcResponse (/Users/bensniff/Projects/gnosis/gp-v2-trading-bot/node_modules/hardhat/src/internal/core/providers/http.ts:140:30)
```

When testing with absent network (expecting a default of rinkeby)

```
➜  gp-v2-trading-bot git:(retry-random-token) yarn hardhat trade               
yarn run v1.22.11
$ /Users/bensniff/Projects/gnosis/gp-v2-trading-bot/node_modules/.bin/hardhat trade
An unexpected error occurred.

Unexpected network 31337
```