### PR TITLE
Fix token list on xDAI

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,8 +24,9 @@ export class ChainUtils {
         return "https://raw.githubusercontent.com/Uniswap/token-lists/master/test/schema/bigexample.tokenlist.json";
       case Chain.RINKEBY:
         return "https://raw.githubusercontent.com/Uniswap/token-lists/master/test/schema/bigexample.tokenlist.json";
-      case Chain.XDAI:
-        return "https://tokens.honeyswap.org/";
+      case Chain.XDAI: {
+        return "https://unpkg.com/@1hive/default-token-list/build/honeyswap-default.tokenlist.json";
+      }
     }
   }
 


### PR DESCRIPTION
The xDai trading bot is not working at the moment, because the token list was put behind a cloudfare captcha protection (leading to us not fetching the json but some random webpage asking us to confirm that we are not a robot (which we are)).


This PR changes the Url to the one used by the honeyswap frontend which doesn't have such protection.

### Test Plan

Run trading bot on xDAI and see it works.